### PR TITLE
update api_key to bitski_client_id for usage in other apps

### DIFF
--- a/bitski/src/lib.rs
+++ b/bitski/src/lib.rs
@@ -51,10 +51,11 @@ impl Bitski {
     }
 
     pub fn from_env() -> Result<Self, Error> {
-        let client_id = std::env::var("API_KEY").or_else(|_| std::env::var("CLIENT_ID"))?;
-        let credential_id = std::env::var("CREDENTIAL_ID");
-        let credential_secret = std::env::var("CREDENTIAL_SECRET");
-        let scopes: Vec<String> = std::env::var("SCOPES")
+        let client_id =
+            std::env::var("BITSKI_API_KEY").or_else(|_| std::env::var("BITSKI_CLIENT_ID"))?;
+        let credential_id = std::env::var("BITSKI_CREDENTIAL_ID");
+        let credential_secret = std::env::var("BITSKI_CREDENTIAL_SECRET");
+        let scopes: Vec<String> = std::env::var("BITSKI_SCOPES")
             .unwrap_or_default()
             .split_terminator(',')
             .map(|s| s.to_string())

--- a/bitski/src/lib.rs
+++ b/bitski/src/lib.rs
@@ -51,15 +51,24 @@ impl Bitski {
     }
 
     pub fn from_env() -> Result<Self, Error> {
-        let client_id =
-            std::env::var("BITSKI_API_KEY").or_else(|_| std::env::var("BITSKI_CLIENT_ID"))?;
-        let credential_id = std::env::var("BITSKI_CREDENTIAL_ID");
-        let credential_secret = std::env::var("BITSKI_CREDENTIAL_SECRET");
+        let client_id = std::env::var("BITSKI_API_KEY")
+            .or_else(|_| std::env::var("BITSKI_CLIENT_ID"))
+            .or_else(|_| std::env::var("API_KEY"))
+            .or_else(|_| std::env::var("CLIENT_ID"))?;
+
+        let credential_id =
+            std::env::var("BITSKI_CREDENTIAL_ID").or_else(|_| std::env::var("CREDENTIAL_ID"));
+
+        let credential_secret = std::env::var("BITSKI_CREDENTIAL_SECRET")
+            .or_else(|_| std::env::var("CREDENTIAL_SECRET"));
+
         let scopes: Vec<String> = std::env::var("BITSKI_SCOPES")
+            .or_else(|_| std::env::var("SCOPES"))
             .unwrap_or_default()
             .split_terminator(',')
             .map(|s| s.to_string())
             .collect();
+
         let scopes = match scopes.is_empty() {
             true => None,
             false => Some(scopes),


### PR DESCRIPTION
Adding BITSKI_ prefix to all the env vars for clarity when in use in other applications. Additionally changed API_KEY to BITSKI_CLIENT_ID for consistency. 

What applications is this repo being used in? I will need to coordinate with any stakeholders using this code before any PR merge to ensure the env configurations are aligned.