### PR TITLE
Fix for gas price change in Anvil

### DIFF
--- a/bitski/src/lib.rs
+++ b/bitski/src/lib.rs
@@ -1,10 +1,10 @@
 #[cfg(feature = "local")]
-mod anvil;
-#[cfg(feature = "local")]
 mod local;
+#[cfg(feature = "local")]
+mod node;
 
 #[cfg(feature = "local")]
-pub use crate::anvil::Anvil;
+pub use crate::node::{anvil_config, Anvil};
 
 use anyhow::Error;
 use bitski_chain_models::networks::Network;


### PR DESCRIPTION
Anvil changed their gas price settings to default to London hardfork, which some of our downstream tests aren't expecting. By re-exporting the `NodeConfig` it allows us more control. 